### PR TITLE
Allow ControllerMenuStage to be created with a Batch.

### DIFF
--- a/core-scene2d/src/de/golfgl/gdx/controllers/ControllerMenuStage.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/ControllerMenuStage.java
@@ -29,6 +29,10 @@ public class ControllerMenuStage extends Stage {
         super(viewport);
     }
 
+    public ControllerMenuStage(Viewport viewport, Batch batch) {
+        super(viewport, batch);
+    }
+
     public boolean isFocusOnTouchdown() {
         return focusOnTouchdown;
     }


### PR DESCRIPTION
Since Stage also has a constructor which takes a Batch, and it's impossible to set the Batch after the constructor because it's final, it's important to add this so the migration to this custom Stage is seamless.