### PR TITLE
Add support for lwjgl3 backend

### DIFF
--- a/desktop-jamepad/src/main/java/com/badlogic/gdx/controllers/lwjgl3/Lwjgl3ControllerManager.java
+++ b/desktop-jamepad/src/main/java/com/badlogic/gdx/controllers/lwjgl3/Lwjgl3ControllerManager.java
@@ -1,0 +1,10 @@
+package com.badlogic.gdx.controllers.lwjgl3;
+
+
+import de.golfgl.gdx.controllers.jamepad.JamepadControllerManager;
+
+/**
+ * Total hack to override the default behavior of LibGDX to pickup this controller manager using "classpath magic".
+ */
+public class Lwjgl3ControllerManager extends JamepadControllerManager {
+}


### PR DESCRIPTION
Added a class to trick the Libgdx LWJGL3 backend into loading the JamepadControllerManager, so it also works with LWJGL3.
As mentioned in issue #4 