### PR TITLE
NullPointerException fixes and overridden clear() for convenience

### DIFF
--- a/core-scene2d/src/de/golfgl/gdx/controllers/ControllerMenuStage.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/ControllerMenuStage.java
@@ -93,6 +93,15 @@ public class ControllerMenuStage extends Stage {
             addFocusableActor(actors.get(i));
     }
 
+    /**
+     * Clears all children, listeners, actions and focusable actors from the stage
+     */
+    @Override
+    public void clear() {
+        super.clear();
+        clearFocusableActors();
+    }
+
     public void clearFocusableActors() {
         setFocusedActor(null);
         focusableActors.clear();

--- a/core-scene2d/src/de/golfgl/gdx/controllers/ControllerMenuStage.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/ControllerMenuStage.java
@@ -85,6 +85,8 @@ public class ControllerMenuStage extends Stage {
     }
 
     public void addFocusableActor(Actor actor) {
+        if (actor == null)
+            return;
         focusableActors.add(actor);
     }
 
@@ -112,7 +114,7 @@ public class ControllerMenuStage extends Stage {
      */
     public void removeFocusableActorsNotOnStage() {
         for (int i = focusableActors.size - 1; i >= 0; i--) {
-            if (focusableActors.get(i).getStage() != this)
+            if (focusableActors.get(i) == null || focusableActors.get(i).getStage() != this)
                 focusableActors.removeIndex(i);
         }
     }
@@ -205,6 +207,9 @@ public class ControllerMenuStage extends Stage {
      * @return true if focusable
      */
     protected boolean isActorFocusable(Actor actor) {
+        if (actor == null)
+            return false;
+
         if (!focusableActors.contains(actor, true))
             return false;
 


### PR DESCRIPTION
This will fix issue #26 with the null pointer exceptions.
Added a commit that override clear() as clear without clearing focusable actors could also lead to issues and imho should clear should clear all including the focusable actors array and selected.