### PR TITLE
Add focusable variants of widgets

### DIFF
--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableActorCompat.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableActorCompat.java
@@ -1,0 +1,23 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import de.golfgl.gdx.controllers.ControllerMenuStage;
+
+/**
+ * Convenience wrapper for setting a focusable actor when the stage is typed {@link Stage}
+ */
+public class FocusableActorCompat {
+
+    private FocusableActorCompat() {
+    }
+
+    /**
+     * Usable in {@link Actor#setStage(Stage)} to set an actor as focusable without casting every time.
+     */
+    public static void setFocusable(Actor actor, Stage stage) {
+        if (stage instanceof ControllerMenuStage) {
+            ((ControllerMenuStage) stage).addFocusableActor(actor);
+        }
+    }
+}

--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableButton.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableButton.java
@@ -1,0 +1,55 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Button;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
+
+public class FocusableButton extends Button {
+
+    public FocusableButton(Skin skin) {
+        super(skin);
+    }
+
+    public FocusableButton(Skin skin, String styleName) {
+        super(skin, styleName);
+    }
+
+    public FocusableButton(Actor child, Skin skin, String styleName) {
+        super(child, skin, styleName);
+    }
+
+    public FocusableButton(Actor child, ButtonStyle style) {
+        super(child, style);
+    }
+
+    public FocusableButton(ButtonStyle style) {
+        super(style);
+    }
+
+    public FocusableButton() {
+    }
+
+    public FocusableButton(Drawable up) {
+        super(up);
+    }
+
+    public FocusableButton(Drawable up, Drawable down) {
+        super(up, down);
+    }
+
+    public FocusableButton(Drawable up, Drawable down, Drawable checked) {
+        super(up, down, checked);
+    }
+
+    public FocusableButton(Actor child, Skin skin) {
+        super(child, skin);
+    }
+
+    @Override
+    protected void setStage(Stage stage) {
+        super.setStage(stage);
+        FocusableActorCompat.setFocusable(this, stage);
+    }
+}

--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableCheckBox.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableCheckBox.java
@@ -1,0 +1,25 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.CheckBox;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+
+public class FocusableCheckBox extends CheckBox {
+    public FocusableCheckBox(String text, Skin skin) {
+        super(text, skin);
+    }
+
+    public FocusableCheckBox(String text, Skin skin, String styleName) {
+        super(text, skin, styleName);
+    }
+
+    public FocusableCheckBox(String text, CheckBoxStyle style) {
+        super(text, style);
+    }
+
+    @Override
+    protected void setStage(Stage stage) {
+        super.setStage(stage);
+        FocusableActorCompat.setFocusable(this, stage);
+    }
+}

--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableImage.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableImage.java
@@ -1,0 +1,50 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.NinePatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
+import com.badlogic.gdx.utils.Scaling;
+
+public class FocusableImage extends Image {
+
+    public FocusableImage() {
+    }
+
+    public FocusableImage(NinePatch patch) {
+        super(patch);
+    }
+
+    public FocusableImage(TextureRegion region) {
+        super(region);
+    }
+
+    public FocusableImage(Texture texture) {
+        super(texture);
+    }
+
+    public FocusableImage(Skin skin, String drawableName) {
+        super(skin, drawableName);
+    }
+
+    public FocusableImage(Drawable drawable) {
+        super(drawable);
+    }
+
+    public FocusableImage(Drawable drawable, Scaling scaling) {
+        super(drawable, scaling);
+    }
+
+    public FocusableImage(Drawable drawable, Scaling scaling, int align) {
+        super(drawable, scaling, align);
+    }
+
+    @Override
+    protected void setStage(Stage stage) {
+        super.setStage(stage);
+        FocusableActorCompat.setFocusable(this, stage);
+    }
+}

--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableImageButton.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableImageButton.java
@@ -1,0 +1,39 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.ImageButton;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
+
+public class FocusableImageButton extends ImageButton {
+
+    public FocusableImageButton(Skin skin) {
+        super(skin);
+    }
+
+    public FocusableImageButton(Skin skin, String styleName) {
+        super(skin, styleName);
+    }
+
+    public FocusableImageButton(ImageButtonStyle style) {
+        super(style);
+    }
+
+    public FocusableImageButton(Drawable imageUp) {
+        super(imageUp);
+    }
+
+    public FocusableImageButton(Drawable imageUp, Drawable imageDown) {
+        super(imageUp, imageDown);
+    }
+
+    public FocusableImageButton(Drawable imageUp, Drawable imageDown, Drawable imageChecked) {
+        super(imageUp, imageDown, imageChecked);
+    }
+
+    @Override
+    protected void setStage(Stage stage) {
+        super.setStage(stage);
+        FocusableActorCompat.setFocusable(this, stage);
+    }
+}

--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableImageTextButton.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableImageTextButton.java
@@ -1,0 +1,26 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.ImageTextButton;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+
+public class FocusableImageTextButton extends ImageTextButton {
+
+    public FocusableImageTextButton(String text, Skin skin) {
+        super(text, skin);
+    }
+
+    public FocusableImageTextButton(String text, Skin skin, String styleName) {
+        super(text, skin, styleName);
+    }
+
+    public FocusableImageTextButton(String text, ImageTextButtonStyle style) {
+        super(text, style);
+    }
+
+    @Override
+    protected void setStage(Stage stage) {
+        super.setStage(stage);
+        FocusableActorCompat.setFocusable(this, stage);
+    }
+}

--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableLabel.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableLabel.java
@@ -1,0 +1,35 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+
+public class FocusableLabel extends Label {
+
+    public FocusableLabel(CharSequence text, Skin skin) {
+        super(text, skin);
+    }
+
+    public FocusableLabel(CharSequence text, Skin skin, String styleName) {
+        super(text, skin, styleName);
+    }
+
+    public FocusableLabel(CharSequence text, Skin skin, String fontName, Color color) {
+        super(text, skin, fontName, color);
+    }
+
+    public FocusableLabel(CharSequence text, Skin skin, String fontName, String colorName) {
+        super(text, skin, fontName, colorName);
+    }
+
+    public FocusableLabel(CharSequence text, LabelStyle style) {
+        super(text, style);
+    }
+
+    @Override
+    protected void setStage(Stage stage) {
+        super.setStage(stage);
+        FocusableActorCompat.setFocusable(this, stage);
+    }
+}

--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableTextArea.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableTextArea.java
@@ -1,0 +1,26 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.TextArea;
+
+public class FocusableTextArea extends TextArea {
+
+    public FocusableTextArea(String text, Skin skin) {
+        super(text, skin);
+    }
+
+    public FocusableTextArea(String text, Skin skin, String styleName) {
+        super(text, skin, styleName);
+    }
+
+    public FocusableTextArea(String text, TextFieldStyle style) {
+        super(text, style);
+    }
+
+    @Override
+    protected void setStage(Stage stage) {
+        super.setStage(stage);
+        FocusableActorCompat.setFocusable(this, stage);
+    }
+}

--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableTextButton.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableTextButton.java
@@ -1,0 +1,26 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+
+public class FocusableTextButton extends TextButton {
+
+    public FocusableTextButton(String text, Skin skin) {
+        super(text, skin);
+    }
+
+    public FocusableTextButton(String text, Skin skin, String styleName) {
+        super(text, skin, styleName);
+    }
+
+    public FocusableTextButton(String text, TextButtonStyle style) {
+        super(text, style);
+    }
+
+    @Override
+    protected void setStage(Stage stage) {
+        super.setStage(stage);
+        FocusableActorCompat.setFocusable(this, stage);
+    }
+}

--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableTextField.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableTextField.java
@@ -1,0 +1,26 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.TextField;
+
+public class FocusableTextField extends TextField {
+
+    public FocusableTextField(String text, Skin skin) {
+        super(text, skin);
+    }
+
+    public FocusableTextField(String text, Skin skin, String styleName) {
+        super(text, skin, styleName);
+    }
+
+    public FocusableTextField(String text, TextFieldStyle style) {
+        super(text, style);
+    }
+
+    @Override
+    protected void setStage(Stage stage) {
+        super.setStage(stage);
+        FocusableActorCompat.setFocusable(this, stage);
+    }
+}

--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableWidget.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableWidget.java
@@ -1,0 +1,14 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Widget;
+
+public class FocusableWidget extends Widget {
+
+
+    @Override
+    protected void setStage(Stage stage) {
+        super.setStage(stage);
+        FocusableActorCompat.setFocusable(this, stage);
+    }
+}

--- a/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableWidgetGroup.java
+++ b/core-scene2d/src/de/golfgl/gdx/controllers/focusable/FocusableWidgetGroup.java
@@ -1,0 +1,21 @@
+package de.golfgl.gdx.controllers.focusable;
+
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.WidgetGroup;
+
+public class FocusableWidgetGroup extends WidgetGroup {
+
+    public FocusableWidgetGroup() {
+    }
+
+    public FocusableWidgetGroup(Actor... actors) {
+        super(actors);
+    }
+
+    @Override
+    protected void setStage(Stage stage) {
+        super.setStage(stage);
+        FocusableActorCompat.setFocusable(this, stage);
+    }
+}


### PR DESCRIPTION
This PR adds a set of actors to the scene2d extensions that mimic scene2d's default widgets, but automatically declare themselves to be focusable on `setStage`